### PR TITLE
_.map for more than 1 iterator

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -213,14 +213,14 @@
         <div class='function' id='map'>
           <p>
             <strong class='name'>map</strong>
-            <code>_.map(iter, func)</code>
+            <code>_.map(iter1, ..., func)</code>
             <span class='alias'>
               Aliases:
               <strong>collect</strong>
             </span>
           </p>
-          <p class='description'>Produces a new array by mapping each value in iter through a transformation function.</p>
-          <pre class='example'>_.map({1,2,3}, function(i) return i*2 end)&#x000A;=> { 2,4,6 }</pre>
+          <p class='description'>Produces one new array by mapping each value in iter1 etc. through a transformation function. Works for one or multiple iterators.</p>
+          <pre class='example'>_.map({1,2,3}, function(i) return i*2 end)&#x000A;=> { 2,4,6 }&#x000A;_.map({1,2,3}, {3,2,1}, function(a,b) return a+b end)&#x000A;=> { 4,4,4 }</pre>
         </div>
         <div class='function' id='each'>
           <p>

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -89,11 +89,16 @@ function Underscore.funcs.each(list, func)
 	return list
 end
 
-function Underscore.funcs.map(list, func)
+function Underscore.funcs.map(...)
 	local mapped = {}
-	for i in Underscore.iter(list) do
-		mapped[#mapped+1] = func(i)
-	end	
+	local func = arg[arg.n]
+	local iters = {}
+	for i = 1,arg.n-1 do iters[i] = Underscore.iter(arg[i]) end
+	for v1 in iters[1] do
+		local vals = {}
+		for i = 2, #iters do vals[i-1] = iters[i]() end
+		mapped[#mapped+1] = func(v1, unpack(vals))
+	end
 	return mapped
 end
 

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -89,14 +89,14 @@ function Underscore.funcs.each(list, func)
 	return list
 end
 
-function Underscore.funcs.map(...)
+function Underscore.funcs.map(iter1, ...)
 	local mapped = {}
 	local func = arg[arg.n]
-	local iters = {}
-	for i = 1,arg.n-1 do iters[i] = Underscore.iter(arg[i]) end
-	for v1 in iters[1] do
+	local remaining_iters = {}
+	for i = 1,arg.n-1 do remaining_iters[i] = Underscore.iter(arg[i]) end
+	for v1 in Underscore.iter(iter1) do
 		local vals = {}
-		for i = 2, #iters do vals[i-1] = iters[i]() end
+		for i = 1, #remaining_iters do vals[i] = remaining_iters[i]() end
 		mapped[#mapped+1] = func(v1, unpack(vals))
 	end
 	return mapped

--- a/spec/map_spec.lua
+++ b/spec/map_spec.lua
@@ -2,12 +2,19 @@ require 'spec_helper'
 
 describe["_.map"] = function()
 	before = function()
-		input = { 1,2,3 }
-		result = _.map(input, function(i) return i*2 end)
+		input1 = { 1,2,3 }
+		result_one_iter = _.map(input1, function(i) return i*2 end)
+		input2 = { 2,3,4,5 }
+		input3 = { 3,4,5,6 }
+		result_three_iters = _.map(input1, input2, input3, function(a,b,c) return a+b+c end)
+	end
+
+	it["should return an array of the same size with all elements transformed by the function"] = function()
+		expect(result_one_iter).should_equal {2,4,6}
 	end
 	
-	it["should return an array of the same size with all elements transformed by the function"] = function()
-		expect(result).should_equal {2,4,6}
+	it["should return one array of the size of the first argument with all elements transformed by the function"] = function()
+		expect(result_three_iters).should_equal {6,9,12}
 	end
 end
 

--- a/template/functions.yaml
+++ b/template/functions.yaml
@@ -6,12 +6,14 @@ iterator_functions:
       aliases:
         - collect
       params: 
-        iter, func
+        iter1, ..., func
       description:
-        Produces a new array by mapping each value in iter through a transformation function.
+        Produces one new array by mapping each value in iter1 etc. through a transformation function. Works for one or multiple iterators.
       example: |
         _.map({1,2,3}, function(i) return i*2 end)
         => { 2,4,6 }
+        _.map({1,2,3}, {3,2,1}, function(a,b) return a+b end)
+        => { 4,4,4 }
 
     - name: 
         each


### PR DESCRIPTION
I found it pretty handy, what do you think?
    _.map( {1,2,3}, {3,2,1}, function(a,b) return a+b end )
    => {4,4,4}
