### PR TITLE
Support for simple_reduce and multi_map.

### DIFF
--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -384,6 +384,12 @@ function Underscore.funcs.pop(array)
 	return table.remove(array)
 end
 
+Underscore.funcs.clear = (function ()
+	return function (array)
+		Underscore.funcs.safe_each (array, function () Underscore.funcs.pop (array) end)
+	end
+end)()
+
 Underscore.funcs.append = (function ()
 	return function (array, ...)
 		local acc = {unpack (array)}  -- identity, abstract away later
@@ -428,9 +434,23 @@ function Underscore.funcs.unshift(array, item)
 	return array
 end
 
+Underscore.funcs.grab = (function ()
+	return function (list, idx) return table.remove(list, idx) end
+end)()
+
 function Underscore.funcs.join(array, separator)
 	return table.concat(array, separator)
 end
+
+Underscore.funcs.shuffle = (function ()
+	return function (list)
+		math.randomseed (os.time ())
+		list = {unpack (list)}
+		local acc = {}
+		Underscore.funcs.safe_each (list, function () Underscore.funcs.push (acc, Underscore.funcs.grab(list, math.random (#list))) end)
+		return acc
+	end
+end)()
 
 -- objects
 

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -90,12 +90,19 @@ end
 
 -- iter
 
-function Underscore.funcs.each(list, func)
-	for i in Underscore.iter(list) do
-		func(i)
+Underscore.funcs.each = (function()
+	local inner
+	inner = function(iter, func)
+		local _ = iter()
+		if _ then
+			func(_)
+			return inner(iter, func) end
 	end
-	return list
-end
+	local each = function(list_or_iter, func)
+		inner(Underscore.iter(list_or_iter), func)
+		return list_or_iter end
+	return each
+end)()
 
 function Underscore.funcs.map(list, func)
 	local mapped = {}
@@ -218,9 +225,7 @@ end
 
 function Underscore.funcs.reverse(list)
 	local reversed = {}
-	for i in Underscore.iter(list) do
-		table.insert(reversed, 1, i)
-	end	
+	Underscore.funcs.each(list, function(item) table.insert(reversed, 1, item) end)
 	return reversed
 end
 

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -415,6 +415,10 @@ Underscore.funcs.flatten_once = (function ()
 		return Underscore.funcs.append_all (_, unpack (Underscore.funcs.rest (array))) end
 end)()
 
+Underscore.funcs.safe_each = (function ()
+	return function (list, func) return Underscore.funcs.each (Underscore.rangeV2 (1, #list), func) end
+end)()
+
 function Underscore.funcs.shift(array)
 	return table.remove(array, 1)
 end

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -59,6 +59,19 @@ function Underscore.range(start_i, end_i, step)
 	return Underscore:new(range_iter)
 end
 
+function Underscore.rangeV2(start_i, end_i, step)
+	if end_i == nil then
+		end_i = start_i
+		start_i = 1
+	end
+	step = step or 1
+	return coroutine.wrap(function() 
+		for i=start_i, end_i, step do
+			coroutine.yield(i)
+		end
+	end)
+end
+
 -- adds a universal table iterator
 Underscore.table_iterator = function(table)
 	return coroutine.wrap(function() 
@@ -286,6 +299,14 @@ Underscore.funcs.multi_map = (function()
 		inner(iters, func, accumulator)
 		return accumulator end
 	return multi_map end)()
+
+-- our classic zip function, has almost the same signature as multi-map, but omits the callback
+Underscore.funcs.zip = (function()
+	local zip = function (lists_or_iters)
+		return Underscore.funcs.multi_map(lists_or_iters, function(...) return {...} end)
+	end
+	return zip
+end)()
 
 Underscore.funcs.each_while = (function()
 	local each_while = function (lists_or_iters, func, predicate)

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -227,46 +227,46 @@ end
 
 -- usage: simple_reduce({...}, callback), where callback = function(x, y) <body> end
 -- simplifies a reduce function by ditching the memo base case
--- @param list_or_iter, following the underscoreLua specs
--- @param func, a callback of the form x -> y -> z
--- returns a list
+-- @param : list_or_iter, following the underscoreLua specs
+-- @param : func, a callback of the form x -> y -> z
+-- @return : a list
 Underscore.funcs.simple_reduce = (function()
 	local inner
 	inner = function(iter, func, accumulator)
-		local value = iter()
-		if value then
-			accumulator.value = func(accumulator.value, value)
+		local _ = iter()
+		if _ then
+			accumulator.value = func(accumulator.value, _)
 			inner(iter, func, accumulator)
 		end
 	end
-	local red = function(list_or_iter, func)
+	local simple_reduce = function(list_or_iter, func)
 		local accumulator = {}
 		local iter = Underscore.iter(list_or_iter)
 		accumulator.value = iter()
 		inner(iter, func, accumulator)
 		return accumulator.value
 	end
-	return red
+	return simple_reduce
 end)()
 
 -- usage: multi_map({{...}, {...}, ...}, callback), where callback = function(<number of items in arg1>) <body> end
 -- provides a map function for an arbitrary number of lists and/or iterators
--- @param lists_or_iters, a list of lists and/or iterators following the underscoreLua specs
--- @param func, a callback that takes the same amount of arguments as there are items in lists_or_iters
+-- @param : lists_or_iters, a list of lists and/or iterators following the underscoreLua specs
+-- @param : func, a callback that takes the same amount of arguments as there are items in lists_or_iters
 -- the function stops execution immediately upon finding a nil value in any of the items in each of the lists_or_iters
 -- the use of iterators or lists with holes is therefore discouraged, a very useful side-effect of this behaviour is that
 -- the function will cater itself towards the iterator or list with the least amout of items
--- returns a list
+-- @return : a list
 Underscore.funcs.multi_map = (function()
 	local inner
 	inner = function(iters, func, accumulator)
-		local args = {}
-		local arg
+		local _
+		local _s = {}
 		if Underscore.funcs.detect(iters, function(iter)
-			arg = iter()
-			table.insert(args, arg)
-			return not arg end) then return end
-		table.insert(accumulator, func(unpack(args)))
+			_ = iter()
+			table.insert(_s, _)
+			return not _ end) then return end
+		table.insert(accumulator, func(unpack(_s)))
 		inner(iters, func, accumulator)
 	end
 	local multi_map = function(lists_or_iters, func)

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -128,7 +128,7 @@ end
 function Underscore.funcs.reduce(list, memo, func)	
 	for i in Underscore.iter(list) do
 		memo = func(memo, i)
-	end	
+	end
 	return memo
 end
 
@@ -465,7 +465,7 @@ end
 function Underscore.funcs.compose(...)
 	local function call_funcs(funcs, ...)
 		if #funcs > 1 then
-			return funcs[1](call_funcs(_.rest(funcs), ...))
+			return funcs[1](call_funcs(Underscore.funcs.rest(funcs), ...))
 		else
 			return funcs[1](...)
 		end
@@ -505,7 +505,7 @@ Underscore.funcs.negate = (function()
 	return negate
 end)()
 
-function Underscore.functions() 
+function Underscore.functions()
 	return Underscore.keys(Underscore.funcs)
 end
 
@@ -541,7 +541,7 @@ local function wrap_functions_for_oo_support()
 		Underscore[fn] = function(obj_or_self, ...)
 			local obj, chained = value_and_chained(obj_or_self)	
 			return value_or_wrap(func(obj, ...), chained)		
-		end
+		end	 
 	end
 end
 

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -386,10 +386,33 @@ end
 
 Underscore.funcs.append = (function ()
 	return function (array, ...)
-		local acc = {unpack (array)}
+		local acc = {unpack (array)}  -- identity, abstract away later
 		Underscore.funcs.each ({...}, function (item) Underscore.funcs.push (acc, item) end)
 		return acc
 	end
+end)()
+
+Underscore.funcs.destructive_append = (function ()
+	return function (array, ...)
+		Underscore.funcs.each ({...}, function (item) Underscore.funcs.push (array, item) end)
+		return array
+	end
+end)()
+
+Underscore.funcs.append_all = (function ()
+	return function (array, ...)
+		local acc = {unpack (array)}  -- identity, abstract away later
+		Underscore.funcs.each ({...}, function (item) Underscore.funcs.destructive_append (acc, unpack (item)) end)
+		return acc
+	end
+end)()
+
+Underscore.funcs.flatten_once = (function ()
+	return function (array)
+		if Underscore.funcs.is_empty (array) then return array end
+		local _ = Underscore.funcs.first (array)
+		if #array == 1 then return _ end
+		return Underscore.funcs.append_all (_, unpack (Underscore.funcs.rest (array))) end
 end)()
 
 function Underscore.funcs.shift(array)

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -228,7 +228,7 @@ end
 -- usage: simple_reduce({...}, callback), where callback = function(x, y) <body> end
 -- simplifies a reduce function by ditching the memo base case
 -- @param : list_or_iter, following the underscoreLua specs
--- @param : func, a callback of the form x -> y -> z
+-- @param : func, a callback of the form x -> y -> list of z
 -- @return : a list
 Underscore.funcs.simple_reduce = (function()
 	local inner
@@ -255,7 +255,7 @@ end)()
 -- @param : func, a callback that takes the same amount of arguments as there are items in lists_or_iters
 -- the function stops execution immediately upon finding a nil value in any of the items in each of the lists_or_iters
 -- the use of iterators or lists with holes is therefore discouraged, a very useful side-effect of this behaviour is that
--- the function will cater itself towards the iterator or list with the least amout of items
+-- the function will cater itself towards the iterator or list with the least amount of items
 -- @return : a list
 Underscore.funcs.multi_map = (function()
 	local inner

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -244,7 +244,7 @@ Underscore.funcs.simple_reduce = (function()
 		local _ = iter()
 		if _ then
 			accumulator.value = func(accumulator.value, _)
-			inner(iter, func, accumulator)
+			return inner(iter, func, accumulator)
 		end
 	end
 	local simple_reduce = function(list_or_iter, func)
@@ -275,7 +275,7 @@ Underscore.funcs.multi_map = (function()
 			table.insert(_s, _)
 			return _ end) then
 		table.insert(accumulator, func(unpack(_s)))
-		inner(iters, func, accumulator) end
+		return inner(iters, func, accumulator) end
 	end
 	local multi_map = function(lists_or_iters, func)
 		local accumulator = {}

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -239,19 +239,10 @@ end
 -- @param : func, a callback of the form x -> y -> list of z
 -- @return : a list
 Underscore.funcs.simple_reduce = (function()
-	local inner
-	inner = function(iter, func, accumulator)
-		local _ = iter()
-		if _ then
-			accumulator.value = func(accumulator.value, _)
-			return inner(iter, func, accumulator) end
-	end
 	local simple_reduce = function(list_or_iter, func)
-		local accumulator = {}
 		local iter = Underscore.iter(list_or_iter)
-		accumulator.value = iter()
-		inner(iter, func, accumulator)
-		return accumulator.value end
+		local _ = iter()
+		return Underscore.funcs.reduce(iter, _, func) end
 	return simple_reduce
 end)()
 

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -384,6 +384,14 @@ function Underscore.funcs.pop(array)
 	return table.remove(array)
 end
 
+Underscore.funcs.append = (function ()
+	return function (array, ...)
+		local acc = {unpack (array)}
+		Underscore.funcs.each ({...}, function (item) Underscore.funcs.push (acc, item) end)
+		return acc
+	end
+end)()
+
 function Underscore.funcs.shift(array)
 	return table.remove(array, 1)
 end
@@ -533,7 +541,7 @@ local function wrap_functions_for_oo_support()
 		Underscore[fn] = function(obj_or_self, ...)
 			local obj, chained = value_and_chained(obj_or_self)	
 			return value_or_wrap(func(obj, ...), chained)		
-		end	 
+		end
 	end
 end
 

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -147,7 +147,8 @@ Underscore.funcs.detect_predicate = (function()
 			return condition end))
 		return condition
 	end
-	return detect_predicate end)()
+	return detect_predicate
+end)()
 
 function Underscore.funcs.select(list, func)
 	local selected = {}
@@ -269,7 +270,8 @@ Underscore.funcs.simple_reduce = (function()
 		local iter = Underscore.iter(list_or_iter)
 		local _ = iter()
 		return Underscore.funcs.reduce(iter, _, func) end
-	return simple_reduce end)()
+	return simple_reduce
+end)()
 
 -- usage: multi_map({{...}, {...}, ...}, callback), where callback = function(<number of items in arg1>) <body> end
 -- provides a map function for an arbitrary number of lists and/or iterators
@@ -296,7 +298,8 @@ Underscore.funcs.multi_map = (function()
 		local iters = Underscore.funcs.map(lists_or_iters, Underscore.iter)
 		inner(iters, func, accumulator)
 		return accumulator end
-	return multi_map end)()
+	return multi_map
+end)()
 
 -- our classic zip function, has almost the same signature as multi-map, but omits the callback
 Underscore.funcs.zip = (function()
@@ -313,13 +316,15 @@ Underscore.funcs.each_while = (function()
 			if go then callback(...) end
 			return go end)
 		Underscore.funcs.all(lists_or_iters, func) end
-	return each_while end)()
+	return each_while
+end)()
 
 Underscore.funcs.each_untill = (function()
 	local each_untill = function (lists_or_iters, func, predicate)
 		predicate = Underscore.funcs.negate(predicate)
 		Underscore.funcs.each_while(lists_or_iters, func, predicate) end
-	return each_untill end)()
+	return each_untill
+end)()
 
 -- arrays
 
@@ -489,7 +494,8 @@ Underscore.funcs.negate = (function()
 			predicate = Underscore.funcs.wrap(predicate, function(callback, ...)
 			return not callback(...) end)
 		return predicate end
-	return negate end)()
+	return negate
+end)()
 
 function Underscore.functions() 
 	return Underscore.keys(Underscore.funcs)

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -59,6 +59,14 @@ function Underscore.range(start_i, end_i, step)
 	return Underscore:new(range_iter)
 end
 
+-- adds a universal table iterator
+Underscore.table_iterator = function(table)
+	return coroutine.wrap(function() 
+	for key, value in pairs(table) do
+		coroutine.yield({key = key, value = value}) end
+	end)
+end
+
 --- Identity function. This function looks useless, but is used throughout Underscore as a default.
 -- @name _.identity
 -- @param value any object
@@ -262,12 +270,12 @@ Underscore.funcs.multi_map = (function()
 	inner = function(iters, func, accumulator)
 		local _
 		local _s = {}
-		if Underscore.funcs.detect(iters, function(iter)
+		if Underscore.funcs.all(iters, function(iter)
 			_ = iter()
 			table.insert(_s, _)
-			return not _ end) then return end
+			return _ end) then
 		table.insert(accumulator, func(unpack(_s)))
-		inner(iters, func, accumulator)
+		inner(iters, func, accumulator) end
 	end
 	local multi_map = function(lists_or_iters, func)
 		local accumulator = {}

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -244,16 +244,14 @@ Underscore.funcs.simple_reduce = (function()
 		local _ = iter()
 		if _ then
 			accumulator.value = func(accumulator.value, _)
-			return inner(iter, func, accumulator)
-		end
+			return inner(iter, func, accumulator) end
 	end
 	local simple_reduce = function(list_or_iter, func)
 		local accumulator = {}
 		local iter = Underscore.iter(list_or_iter)
 		accumulator.value = iter()
 		inner(iter, func, accumulator)
-		return accumulator.value
-	end
+		return accumulator.value end
 	return simple_reduce
 end)()
 
@@ -281,9 +279,25 @@ Underscore.funcs.multi_map = (function()
 		local accumulator = {}
 		local iters = Underscore.funcs.map(lists_or_iters, Underscore.iter)
 		inner(iters, func, accumulator)
-		return accumulator
-	end
+		return accumulator end
 	return multi_map
+end)()
+
+Underscore.funcs.each_while = (function()
+	local each_while = function (lists_or_iters, func, predicate)
+		func = Underscore.funcs.wrap(func, function(callback, ...)
+			local go = predicate(...)
+			if go then callback(...) end
+			return go end)
+		Underscore.funcs.all(lists_or_iters, func) end
+	return each_while
+end)()
+
+Underscore.funcs.each_untill = (function()
+	local each_untill = function (lists_or_iters, func, predicate)
+		predicate = Underscore.funcs.negate(predicate)
+		Underscore.funcs.each_while(lists_or_iters, func, predicate) end
+	return each_untill
 end)()
 
 -- arrays
@@ -440,6 +454,14 @@ function Underscore.funcs.curry(func, argument)
 		return func(argument, ...)
 	end
 end
+
+Underscore.funcs.negate = (function()
+	local negate = function (predicate)
+			predicate = Underscore.funcs.wrap(predicate, function(callback, ...)
+			return not callback(...) end)
+		return predicate end
+	return negate
+end)()
 
 function Underscore.functions() 
 	return Underscore.keys(Underscore.funcs)

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -478,6 +478,14 @@ function Underscore.funcs.curry(func, argument)
 	end
 end
 
+Underscore.funcs.multi_curry = (function()
+	local multi_curry = function (func, ...)
+		Underscore.funcs.each ({...}, function (arg) func = Underscore.funcs.curry(func, arg) end)
+		return function(...) return func(...) end
+	end
+	return multi_curry
+end)()
+
 Underscore.funcs.negate = (function()
 	local negate = function (predicate)
 			predicate = Underscore.funcs.wrap(predicate, function(callback, ...)

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -126,6 +126,16 @@ function Underscore.funcs.detect(list, func)
 	return nil	
 end
 
+Underscore.funcs.detect_predicate = (function()
+	local detect_predicate = function(list, func)
+		local condition
+		Underscore.funcs.any(list, Underscore.funcs.wrap(func, function(callback, item)
+			condition = callback(item)
+			return condition end))
+		return condition
+	end
+	return detect_predicate end)()
+
 function Underscore.funcs.select(list, func)
 	local selected = {}
 	for i in Underscore.iter(list) do
@@ -248,8 +258,7 @@ Underscore.funcs.simple_reduce = (function()
 		local iter = Underscore.iter(list_or_iter)
 		local _ = iter()
 		return Underscore.funcs.reduce(iter, _, func) end
-	return simple_reduce
-end)()
+	return simple_reduce end)()
 
 -- usage: multi_map({{...}, {...}, ...}, callback), where callback = function(<number of items in arg1>) <body> end
 -- provides a map function for an arbitrary number of lists and/or iterators
@@ -276,8 +285,7 @@ Underscore.funcs.multi_map = (function()
 		local iters = Underscore.funcs.map(lists_or_iters, Underscore.iter)
 		inner(iters, func, accumulator)
 		return accumulator end
-	return multi_map
-end)()
+	return multi_map end)()
 
 Underscore.funcs.each_while = (function()
 	local each_while = function (lists_or_iters, func, predicate)
@@ -286,15 +294,13 @@ Underscore.funcs.each_while = (function()
 			if go then callback(...) end
 			return go end)
 		Underscore.funcs.all(lists_or_iters, func) end
-	return each_while
-end)()
+	return each_while end)()
 
 Underscore.funcs.each_untill = (function()
 	local each_untill = function (lists_or_iters, func, predicate)
 		predicate = Underscore.funcs.negate(predicate)
 		Underscore.funcs.each_while(lists_or_iters, func, predicate) end
-	return each_untill
-end)()
+	return each_untill end)()
 
 -- arrays
 
@@ -456,8 +462,7 @@ Underscore.funcs.negate = (function()
 			predicate = Underscore.funcs.wrap(predicate, function(callback, ...)
 			return not callback(...) end)
 		return predicate end
-	return negate
-end)()
+	return negate end)()
 
 function Underscore.functions() 
 	return Underscore.keys(Underscore.funcs)

--- a/lib/underscore.lua
+++ b/lib/underscore.lua
@@ -238,13 +238,11 @@ function Underscore.funcs.max(list, func)
 	end).item
 end
 
-function Underscore.funcs.to_array(list)
-	local array = {}
-	for i in Underscore.iter(list) do
-		array[#array+1] = i
-	end	
-	return array
-end
+Underscore.funcs.to_array = (function ()
+	return function (iter)
+		return Underscore.funcs.map (iter, function (item) return item end)
+	end
+end)()
 
 function Underscore.funcs.reverse(list)
 	local reversed = {}

--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,11 @@
 A Lua version of http://documentcloud.github.com/underscore/, see http://mirven.github.com/underscore.lua/ for more information.
+
+Contains three additions to the core underscore.lua: simple_reduce, multi_map and table_iterator.
+
+simple_reduce doesn't require a base case, it uses the first yield of an iterator passed to it instead.
+
+multi_map can be used on a list of lists of indefinite length, with a callback given having
+a number of arguments equal to the number of iterators in the list of iterators. This function
+caters to the iterator with the least amount of yields.
+
+table_iterator is a simple iterator to run through a table, it yields a key-value pair as a table.

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,13 @@ A Lua version of http://documentcloud.github.com/underscore/, see http://mirven.
 
 Contains three additions to the core underscore.lua: simple_reduce, multi_map and table_iterator.
 
-simple_reduce doesn't require a base case, it uses the first yield of an iterator passed to it instead.
+simple_reduce doesn't require a base case,
+it uses the first yield of an iterator passed to it instead.
 
-multi_map can be used on a list of lists of indefinite length, with a callback given having
-a number of arguments equal to the number of iterators in the list of iterators. This function
-caters to the iterator with the least amount of yields.
+multi_map can be used on a list of lists of indefinite length,
+with a callback given having a number of arguments equal
+to the number of iterators in the list of iterators.
+This function caters to the iterator with the least amount of yields.
 
-table_iterator is a simple iterator to run through a table, it yields a key-value pair as a table.
+table_iterator is a simple iterator to run through a table,
+it yields a key-value pair as a table.

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,7 @@
 A Lua version of http://documentcloud.github.com/underscore/, see http://mirven.github.com/underscore.lua/ for more information.
 
-Contains three additions to the core underscore.lua: simple_reduce, multi_map and table_iterator.
+This fork contains three additions to the core underscore.lua:
+simple_reduce, multi_map and table_iterator.
 
 simple_reduce doesn't require a base case,
 it uses the first yield of an iterator passed to it instead.


### PR DESCRIPTION
Hello there,

I've added a support for simple_reduce, which is basically a reduce that doesn't require a base case
and multi_map. The latter takes a list of lists or iterators and maps every value of those onto a single
list. For example: multi_map({{1, 2, 3}, {6, 7, 8}}, function(x, y) return x + y end) will return {7, 9, 11}.
The first iterative argument can contain an arbitrary amount of nested iterative structures.
